### PR TITLE
Remove Wedgefile

### DIFF
--- a/syntaxes/caddyfile.tmLanguage.json
+++ b/syntaxes/caddyfile.tmLanguage.json
@@ -2,7 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 
 	"name": "Caddyfile",
-	"fileTypes": [ "Caddyfile", "Wedgefile" ],
+	"fileTypes": [ "Caddyfile" ],
 	"scopeName": "source.Caddyfile",
 
 	"patterns": [


### PR DESCRIPTION
[Wedge](https://github.com/WedgeServer/wedge) was a failed fork of Caddy from irate users. There's no reason to keep it listed here.