### PR TITLE
syntax: add support for highlighting in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,16 @@
                 "language": "caddyfile",
                 "scopeName": "source.Caddyfile",
                 "path": "./syntaxes/caddyfile.tmLanguage.json"
+            },
+            {
+                "scopeName": "source.markdown.caddy.codeblock",
+                "path": "./syntaxes/caddy-markdown.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.caddy": "caddyfile"
+                }
             }
         ],
         "configurationDefaults": {

--- a/syntaxes/caddy-markdown.tmLanguage.json
+++ b/syntaxes/caddy-markdown.tmLanguage.json
@@ -3,47 +3,47 @@
 
 	"scopeName": "source.markdown.caddy.codeblock",
 	"injectionSelector": "L:text.html.markdown",
-	"fileTypes": [],
 
 	"patterns": [
-		{
-			"include": "#caddy-code-block"
-		},
-		{
-			"include": "#caddy-d-code-block"
-		}
+		{ "include": "#caddy-code-block" },
+		{ "include": "#caddy-d-code-block" }
 	],
 
 	"repository": {
 		"caddy-code-block": {
-			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(caddy)(\\s+[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
+
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(caddy)(\\s+[^`~]*)?$)",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+
 			"beginCaptures": {
 				"3": {
 					"name": "punctuation.definition.markdown"
 				},
+
 				"5": {
 					"name": "fenced_code.block.language"
 				},
+
 				"6": {
 					"name": "fenced_code.block.language.attributes"
 				}
 			},
+
 			"endCaptures": {
 				"3": {
 					"name": "punctuation.definition.markdown"
 				}
 			},
+
 			"patterns": [
 				{
 					"begin": "(^|\\G)(\\s*)(.*)",
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 					"contentName": "meta.embedded.block.caddy",
+
 					"patterns": [
-						{
-							"include": "source.Caddyfile"
-						}
+						{ "include": "source.Caddyfile" }
 					]
 				}
 			]
@@ -51,7 +51,6 @@
 
 		"caddy-d-code-block": {
 			"name": "markup.fenced_code.block.markdown",
-
 			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(caddy-d)(\\s+[^`~]*)?$)",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 
@@ -80,10 +79,9 @@
 					"begin": "(^|\\G)(\\s*)(.*)",
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
 					"contentName": "meta.embedded.block.caddy",
+
 					"patterns": [
-						{
-							"include": "source.Caddyfile"
-						}
+						{ "include": "source.Caddyfile#block_content" }
 					]
 				}
 			]

--- a/syntaxes/caddy-markdown.tmLanguage.json
+++ b/syntaxes/caddy-markdown.tmLanguage.json
@@ -1,0 +1,92 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+
+	"scopeName": "source.markdown.caddy.codeblock",
+	"injectionSelector": "L:text.html.markdown",
+	"fileTypes": [],
+
+	"patterns": [
+		{
+			"include": "#caddy-code-block"
+		},
+		{
+			"include": "#caddy-d-code-block"
+		}
+	],
+
+	"repository": {
+		"caddy-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(caddy)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.caddy",
+					"patterns": [
+						{
+							"include": "source.Caddyfile"
+						}
+					]
+				}
+			]
+		},
+
+		"caddy-d-code-block": {
+			"name": "markup.fenced_code.block.markdown",
+
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(caddy-d)(\\s+[^`~]*)?$)",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.caddy",
+					"patterns": [
+						{
+							"include": "source.Caddyfile"
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/syntaxes/caddyfile.tmLanguage.json
+++ b/syntaxes/caddyfile.tmLanguage.json
@@ -185,6 +185,16 @@
 					"end": "\\}",
 
 					"patterns": [
+						{ "include": "#block_content" }
+					]
+				}
+			]
+		},
+
+		"block_content": {
+			"patterns": [
+				{
+					"patterns": [
 						{ "include": "#comments" },
 						{ "include": "#strings" },
 						{ "include": "#domains" },

--- a/syntaxes/caddyfile.tmLanguage.json
+++ b/syntaxes/caddyfile.tmLanguage.json
@@ -81,9 +81,9 @@
 		"domains": {
 			"patterns": [
 				{
-					"comment": "Domains and URLs",
+					"comment": "Domains and URLs - https://regexr.com/5spn6",
 					"name": "keyword.control.caddyfile",
-					"match": "(https?:\/\/)*[a-zA-Z0-9][a-zA-Z0-9-]*(?:\\.[a-zA-Z]{2,})+(:[0-9]+)*\\S*"
+					"match": "(https?:\/\/)*[a-z0-9-\\*]*(?:\\.[a-zA-Z]{2,})+(:[0-9]+)*\\S*"
 				},
 				{
 					"comment": "localhost",
@@ -163,6 +163,17 @@
 				{
 					"name": "entity.name.function.Caddyfile",
 					"match": "^\\s*[a-zA-Z_\\-+]+"
+				},
+				{ "include": "#content_types" }
+			]
+		},
+
+		"content_types": {
+			"patterns": [
+				{
+					"comment": "Content Types",
+					"name": "variable.other.property.caddyfile",
+					"match": "(application|audio|example|font|image|message|model|multipart|text|video)\/[a-zA-Z0-9*+\\-.]+;* *[a-zA-Z0-9=\\-]*"
 				}
 			]
 		},


### PR DESCRIPTION
Adds support for caddyfile syntax highlighting in markdown.

Both
~~~
```caddy
```
~~~

~~~
```caddy-d
```
~~~

are supported, however `caddy-d` uses the exact same highlighting as `caddy` due to the way the grammar for this extension is written, which should properly support single-site Caddyfiles.

Closes #18 