### PR TITLE
Remove absolute path check

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -26,11 +26,6 @@ export class CaddyfileDocumentFormattingEditProvider implements vscode.DocumentF
         return new Promise<vscode.TextEdit[]>((resolve, reject) => {
             let executable: string;
             if (executablePath !== undefined && executablePath !== null && executablePath !== "") {
-                if (!path.isAbsolute(executablePath)) {
-                    vscode.window.showInformationMessage("Invalid executable path for caddy.");
-                    return reject();
-                }
-
                 executable = executablePath;
             } else {
                 executable = "caddy";


### PR DESCRIPTION
Fixes https://github.com/matthewpi/vscode-caddyfile-support/issues/56

**Untested**, and as far as I see the `spawn` thing likely makes it impossible to use, i.e. it does not work as I want, does it?

So just consider this as a first try/starter for you. (I have no experience in VS Code development.)